### PR TITLE
Exposed GKAchievement details on getAchievements

### DIFF
--- a/src/ios/GameCenter.m
+++ b/src/ios/GameCenter.m
@@ -261,12 +261,11 @@
                  entry[@"identifier"] = achievement.identifier;
                  entry[@"percentComplete"] = [NSNumber numberWithDouble: achievement.percentComplete];
                  entry[@"completed"] = [NSNumber numberWithBool:achievement.completed];
-                 entry[@"lastReportedDate"] = [NSString stringWithFormat:@"%.0f", [achievement.lastReportedDate timeIntervalSince1970] * 1000];
+                 entry[@"lastReportedDate"] = [NSNumber numberWithDouble:[achievement.lastReportedDate timeIntervalSince1970] * 1000];
                  entry[@"showsCompletionBanner"] = [NSNumber numberWithBool:achievement.showsCompletionBanner];
                  entry[@"playerID"] = achievement.playerID;
                  
                  [earntAchievements addObject:entry];
-
              }
              pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray: earntAchievements];
          }


### PR DESCRIPTION
used timestamp as some json fails to parse obj-c date time properly
